### PR TITLE
Fix: length_scale_prior silently ignored; raise default to [1e-3, 1e2]

### DIFF
--- a/doc/source/module_cobaya.rst
+++ b/doc/source/module_cobaya.rst
@@ -69,7 +69,7 @@ Inside the ``gpry`` block you can specify options for the different GPry modules
        kernel: RBF
        # Priors for the output and length scale, in normalised logp units
        output_scale_prior: [1e-2, 1e3]
-       length_scale_prior: [1e-3, 1e1]
+       length_scale_prior: [1e-3, 1e2]
        # Noise level in logp units; increase for numerically noisy likelihoods
        noise_level: 1e-1
        # Whether to fix the noise or to fit for a white-noise additive kernel term

--- a/gpry/cobaya_interface.py
+++ b/gpry/cobaya_interface.py
@@ -60,7 +60,7 @@ surrogate:
     kernel: RBF
     # Priors for the output and length scale, in normalised logp units
     output_scale_prior: [1e-2, 1e3]
-    length_scale_prior: [1e-3, 1e1]
+    length_scale_prior: [1e-3, 1e2]
     # Noise level in logp units; increase for numerically noisy likelihoods
     noise_level: 1e-1
     # Whether to fix the noise or to fit for a white-noise additive kernel term

--- a/gpry/gpr.py
+++ b/gpry/gpr.py
@@ -200,10 +200,21 @@ class GaussianProcessRegressor(sk_GPR):
                 ) from excpt
             # Build kernel
             output_scale_init = np.sqrt(output_scale_prior[0] * output_scale_prior[1])
-            # Guaranteed to be n-dimensional, if initialised from SurrogateModel
-            length_scale_init = np.sqrt(
-                length_scale_prior[:, 0] * length_scale_prior[:, 1]
-            )
+            # Guaranteed to be n-dimensional, if initialised from SurrogateModel.
+            # When "dynamic", derive an initial scale from the prior widths.
+            if isinstance(length_scale_prior, str) and length_scale_prior == "dynamic":
+                if prior_bounds is None:
+                    raise TypeError(
+                        "prior_bounds is required when length_scale_prior='dynamic'."
+                    )
+                _pb = np.asarray(prior_bounds)
+                _widths = _pb[:, 1] - _pb[:, 0]
+                length_scale_init = 0.1 * _widths
+            else:
+                length_scale_prior = np.asarray(length_scale_prior)
+                length_scale_init = np.sqrt(
+                    length_scale_prior[:, 0] * length_scale_prior[:, 1]
+                )
             # Noise treatment
             self.is_noise_in_kernel = not noise_fixed
             if hasattr(noise_level, "__len__"):

--- a/gpry/gpr.py
+++ b/gpry/gpr.py
@@ -114,6 +114,13 @@ class GaussianProcessRegressor(sk_GPR):
         must be finite. Note that n_restarts_optimizer == 0 implies that one
         run is performed.
 
+    prior_bounds : array-like, shape = (n_dims, 2), optional
+        Bounds of the parameter space, **in the GPR's own (transformed) input space**,
+        i.e. ``preprocessing_X.transform_bounds(bounds)``. Only needed when a length
+        correlation kernel is created with ``length_scale_prior="dynamic"``, in which
+        case the length-scale bounds are derived from the prior size. Supplied by
+        :class:`gpry.surrogate.SurrogateModel`.
+
     random_state : int or numpy.random.Generator, optional
         The generator used to perform random operations of the GPR. If an integer is
         given, it is used as a seed for the default global numpy random number generator.
@@ -160,6 +167,7 @@ class GaussianProcessRegressor(sk_GPR):
         noise_fixed=True,
         optimizer="fmin_l_bfgs_b",
         n_restarts_optimizer=0,
+        prior_bounds=None,
         random_state=None,
     ):
         self.n_eval = 0
@@ -200,7 +208,8 @@ class GaussianProcessRegressor(sk_GPR):
                 [output_scale_prior[0] ** 2, output_scale_prior[1] ** 2],
             ) * length_corr_kernel(
                 length_scale_init,
-                prior_bounds=length_scale_prior,
+                length_scale_prior=length_scale_prior,
+                prior_bounds=prior_bounds,
                 **kernel_args,
             )
             # Use noise level as upper bound if added as additive kernel

--- a/gpry/gpr.py
+++ b/gpry/gpr.py
@@ -64,8 +64,16 @@ class GaussianProcessRegressor(sk_GPR):
     output_scale_prior : tuple as (min, max), optional (default: [1e-2, 1e3])
         Prior for the (non-squared) scale parameter, in normalised logp units.
 
-    length_scale_prior : tuple as (min, max), optional (default: [1e-3, 1e1])
+    length_scale_prior : tuple as (min, max), optional (default: [1e-3, 1e2])
         Prior for the length parameters, as a fraction of the parameter priors sizes.
+        May also be given per-dimension, as an array of shape ``(n_dims, 2)``. Pass the
+        string ``"dynamic"`` to derive the bounds from the prior size instead, which
+        requires ``prior_bounds`` (see :class:`gpry.kernels.Hyperparameter`).
+
+        The upper bound is deliberately well above 1: in the normalised input space a
+        smooth (nearly quadratic) log-posterior is best described by a correlation
+        length several times the prior width, so fitted length scales of O(10) are
+        normal and a tighter bound would clamp them.
 
     noise_level : float or array-like, optional (default: 1e-2)
         Square-root of the value added to the diagonal of the kernel matrix
@@ -162,7 +170,7 @@ class GaussianProcessRegressor(sk_GPR):
         self,
         kernel="RBF",
         output_scale_prior=[1e-2, 1e3],
-        length_scale_prior=[1e-3, 1e1],
+        length_scale_prior=[1e-3, 1e2],
         noise_level=1e-2,
         noise_fixed=True,
         optimizer="fmin_l_bfgs_b",

--- a/gpry/kernels.py
+++ b/gpry/kernels.py
@@ -93,7 +93,11 @@ class Hyperparameter(
         (transformed) input space. Only used for length-scale (correlation
         length) hyperparameters whose bounds are set to "dynamic", to scale
         their allowed range to the prior size. Derived from the ``prior_bounds``
-        passed to the kernel.
+        passed to the kernel. Note: :class:`RationalQuadratic` and
+        :class:`ExpSineSquared` set ``max_length`` to *twice* the prior width
+        (``2 * (upper - lower)``) to accommodate their broader correlation
+        structure, producing dynamic bounds of
+        ``[width * 2e-3, width * 200]``.
     """
 
     # A raw namedtuple is very memory efficient as it packs the attributes

--- a/gpry/kernels.py
+++ b/gpry/kernels.py
@@ -681,7 +681,7 @@ class ExpSineSquared(Kernel, sk_ExpSineSquared):
         if isinstance(length_scale_prior, str) and length_scale_prior == "dynamic":
             if prior_bounds is None:
                 raise TypeError(
-                    "Prior bounds are required for the RQ kernel "
+                    "Prior bounds are required for the ExpSineSquared kernel "
                     "if its hyperparameter bounds are set to 'dynamic'. "
                     "You can either provide these bounds or set the "
                     "hyperparameter bounds to either numeric values or "
@@ -693,7 +693,7 @@ class ExpSineSquared(Kernel, sk_ExpSineSquared):
             if not self.anisotropic:
                 if prior_bounds.shape[0] > 1:
                     warnings.warn(
-                        "The hyperparameter bounds of the isotropic RQ "
+                        "The hyperparameter bounds of the isotropic ExpSineSquared "
                         "kernel were set to 'dynamic' even though the "
                         "posterior distribution has more than one dimension. "
                         "The maximum length scale will be adapted to the "

--- a/gpry/kernels.py
+++ b/gpry/kernels.py
@@ -28,6 +28,8 @@ from sklearn.gaussian_process.kernels import (  # type: ignore
     WhiteKernel as sk_WhiteKernel,
 )
 
+_LSP_DEFAULT = object()  # sentinel for length_scale_prior default
+
 
 class Hyperparameter(
     namedtuple(
@@ -285,8 +287,24 @@ class Kernel(sk_Kernel):
 
 class RBF(Kernel, sk_RBF):
     def __init__(
-        self, length_scale=1.0, length_scale_prior=(1e-3, 1e2), prior_bounds=None
+        self,
+        length_scale=1.0,
+        length_scale_prior=_LSP_DEFAULT,
+        prior_bounds=None,
+        **kwargs,
     ):
+        length_scale_bounds = kwargs.pop("length_scale_bounds", _LSP_DEFAULT)
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {list(kwargs)}")
+        if length_scale_bounds is not _LSP_DEFAULT:
+            if length_scale_prior is not _LSP_DEFAULT and length_scale_prior != length_scale_bounds:
+                raise ValueError(
+                    "Cannot specify both 'length_scale_prior' and 'length_scale_bounds' "
+                    "with different values."
+                )
+            length_scale_prior = length_scale_bounds
+        if length_scale_prior is _LSP_DEFAULT:
+            length_scale_prior = (1e-3, 1e2)
         self.length_scale = length_scale
         self.length_scale_prior = length_scale_prior
         self.prior_bounds = prior_bounds
@@ -360,10 +378,23 @@ class Matern(Kernel, sk_Matern):
     def __init__(
         self,
         length_scale=1.0,
-        length_scale_prior=(1e-3, 1e2),
+        length_scale_prior=_LSP_DEFAULT,
         nu=1.5,
         prior_bounds=None,
+        **kwargs,
     ):
+        length_scale_bounds = kwargs.pop("length_scale_bounds", _LSP_DEFAULT)
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {list(kwargs)}")
+        if length_scale_bounds is not _LSP_DEFAULT:
+            if length_scale_prior is not _LSP_DEFAULT and length_scale_prior != length_scale_bounds:
+                raise ValueError(
+                    "Cannot specify both 'length_scale_prior' and 'length_scale_bounds' "
+                    "with different values."
+                )
+            length_scale_prior = length_scale_bounds
+        if length_scale_prior is _LSP_DEFAULT:
+            length_scale_prior = (1e-3, 1e2)
         self.length_scale = length_scale
         self.length_scale_prior = length_scale_prior
         self.nu = nu
@@ -524,10 +555,23 @@ class RationalQuadratic(Kernel, sk_RationalQuadratic):
         self,
         length_scale=1.0,
         alpha=1.0,
-        length_scale_prior=(1e-3, 1e2),
+        length_scale_prior=_LSP_DEFAULT,
         alpha_bounds=(1e-5, 1e5),
         prior_bounds=None,
+        **kwargs,
     ):
+        length_scale_bounds = kwargs.pop("length_scale_bounds", _LSP_DEFAULT)
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {list(kwargs)}")
+        if length_scale_bounds is not _LSP_DEFAULT:
+            if length_scale_prior is not _LSP_DEFAULT and length_scale_prior != length_scale_bounds:
+                raise ValueError(
+                    "Cannot specify both 'length_scale_prior' and 'length_scale_bounds' "
+                    "with different values."
+                )
+            length_scale_prior = length_scale_bounds
+        if length_scale_prior is _LSP_DEFAULT:
+            length_scale_prior = (1e-3, 1e2)
         self.length_scale = length_scale
         self.alpha = alpha
         self.length_scale_prior = length_scale_prior
@@ -612,10 +656,23 @@ class ExpSineSquared(Kernel, sk_ExpSineSquared):
         self,
         length_scale=1.0,
         periodicity=1.0,
-        length_scale_prior=(1e-3, 1e2),
+        length_scale_prior=_LSP_DEFAULT,
         periodicity_bounds=(1e-5, 1e5),
         prior_bounds=None,
+        **kwargs,
     ):
+        length_scale_bounds = kwargs.pop("length_scale_bounds", _LSP_DEFAULT)
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {list(kwargs)}")
+        if length_scale_bounds is not _LSP_DEFAULT:
+            if length_scale_prior is not _LSP_DEFAULT and length_scale_prior != length_scale_bounds:
+                raise ValueError(
+                    "Cannot specify both 'length_scale_prior' and 'length_scale_bounds' "
+                    "with different values."
+                )
+            length_scale_prior = length_scale_bounds
+        if length_scale_prior is _LSP_DEFAULT:
+            length_scale_prior = (1e-3, 1e2)
         self.length_scale = length_scale
         self.periodicity = periodicity
         self.length_scale_prior = length_scale_prior

--- a/gpry/kernels.py
+++ b/gpry/kernels.py
@@ -76,16 +76,24 @@ class Hyperparameter(
         changed during hyperparameter tuning. If None is passed, the "fixed" is
         derived based on the given bounds.
     dynamic : bool, default=None
-        Whether the value of this hyperparameter is dynamic, i.e. whether the
-        bounds of the hyperparameter should automatically be adjusted to two
-        orders of magnitude above and below the current best fit value. If None
-        is passed, the "dynamic" is derived based on the given bounds.
+        Whether the bounds of this hyperparameter are derived on access rather
+        than fixed. If None, it is derived from the given bounds (True if they
+        were passed as the string "dynamic"). Two cases, see ``max_length``:
+
+        * ``max_length`` is None: the bounds track the *current* value, as
+          ``[value * 1e-3, value * 100]``. Since ``Kernel.bounds`` is a property
+          and the fit reads it once per refit, the search box re-centres on the
+          latest best fit at every refit.
+        * ``max_length`` is given: the bounds are ``[max_length * 1e-3,
+          max_length * 100]``, i.e. fixed but scaled to each parameter's prior
+          size.
     max_length : float or array-like, shape = (n_dimensions,)
-        The prior bounds of the posterior distribution (of the parameter-space,
-        not the hyperparameter space) is required for hyperparameters which are
-        length scales (correlation lengths) if their bounds are set to
-        "dynamic". This is done to restrict their range to the same order of
-        magnitude as the prior size (actually 2x the prior).
+        Size of the parameter-space prior (*not* of the hyperparameter space)
+        per dimension, i.e. ``upper - lower`` of the bounds in the kernel's own
+        (transformed) input space. Only used for length-scale (correlation
+        length) hyperparameters whose bounds are set to "dynamic", to scale
+        their allowed range to the prior size. Derived from the ``prior_bounds``
+        passed to the kernel.
     """
 
     # A raw namedtuple is very memory efficient as it packs the attributes
@@ -273,7 +281,7 @@ class Kernel(sk_Kernel):
 
 class RBF(Kernel, sk_RBF):
     def __init__(
-        self, length_scale=1.0, length_scale_prior=(1e-3, 1e1), prior_bounds=None
+        self, length_scale=1.0, length_scale_prior=(1e-3, 1e2), prior_bounds=None
     ):
         self.length_scale = length_scale
         self.length_scale_prior = length_scale_prior
@@ -348,7 +356,7 @@ class Matern(Kernel, sk_Matern):
     def __init__(
         self,
         length_scale=1.0,
-        length_scale_prior=(1e-3, 1e1),
+        length_scale_prior=(1e-3, 1e2),
         nu=1.5,
         prior_bounds=None,
     ):
@@ -512,7 +520,7 @@ class RationalQuadratic(Kernel, sk_RationalQuadratic):
         self,
         length_scale=1.0,
         alpha=1.0,
-        length_scale_prior=(1e-3, 1e1),
+        length_scale_prior=(1e-3, 1e2),
         alpha_bounds=(1e-5, 1e5),
         prior_bounds=None,
     ):
@@ -600,7 +608,7 @@ class ExpSineSquared(Kernel, sk_ExpSineSquared):
         self,
         length_scale=1.0,
         periodicity=1.0,
-        length_scale_prior=(1e-3, 1e1),
+        length_scale_prior=(1e-3, 1e2),
         periodicity_bounds=(1e-5, 1e5),
         prior_bounds=None,
     ):

--- a/gpry/kernels.py
+++ b/gpry/kernels.py
@@ -151,6 +151,30 @@ class Kernel(sk_Kernel):
         This kernel class is taken entirely from the Scikit-optimize package.
     """
 
+    @property
+    def length_scale_bounds(self):
+        """
+        Backwards-compatible alias for :attr:`length_scale_prior`.
+
+        ``length_scale_bounds`` is sklearn's name for this quantity; gpry calls it
+        ``length_scale_prior``, to distinguish it clearly from ``prior_bounds``
+        (the parameter-space box). Raises ``AttributeError`` for kernels that have
+        no length scale, which is the pre-existing behaviour.
+        """
+        return self.length_scale_prior
+
+    def __setstate__(self, state):
+        """
+        Restore a pickled kernel.
+
+        Handles checkpoints written before ``length_scale_bounds`` was renamed to
+        ``length_scale_prior``: without this, unpickling an older surrogate fails in
+        sklearn's ``get_params``, which reads the attribute named in ``__init__``.
+        """
+        if "length_scale_bounds" in state and "length_scale_prior" not in state:
+            state["length_scale_prior"] = state.pop("length_scale_bounds")
+        self.__dict__.update(state)
+
     def __add__(self, b):
         if not isinstance(b, Kernel):
             return Sum(self, ConstantKernel(b))
@@ -249,12 +273,12 @@ class Kernel(sk_Kernel):
 
 class RBF(Kernel, sk_RBF):
     def __init__(
-        self, length_scale=1.0, length_scale_bounds=(1e-5, 1e5), prior_bounds=None
+        self, length_scale=1.0, length_scale_prior=(1e-3, 1e1), prior_bounds=None
     ):
         self.length_scale = length_scale
-        self.length_scale_bounds = length_scale_bounds
+        self.length_scale_prior = length_scale_prior
         self.prior_bounds = prior_bounds
-        if length_scale_bounds == "dynamic":
+        if isinstance(length_scale_prior, str) and length_scale_prior == "dynamic":
             if prior_bounds is None:
                 raise TypeError(
                     "Prior bounds are required for the RBF kernel "
@@ -288,12 +312,12 @@ class RBF(Kernel, sk_RBF):
             return Hyperparameter(
                 "length_scale",
                 "numeric",
-                self.length_scale_bounds,
+                self.length_scale_prior,
                 self.max_length,
                 len(self.length_scale),
             )
         return Hyperparameter(
-            "length_scale", "numeric", self.length_scale_bounds, self.max_length
+            "length_scale", "numeric", self.length_scale_prior, self.max_length
         )
 
     def gradient_x(self, x, X_train):
@@ -324,15 +348,15 @@ class Matern(Kernel, sk_Matern):
     def __init__(
         self,
         length_scale=1.0,
-        length_scale_bounds=(1e-5, 1e5),
+        length_scale_prior=(1e-3, 1e1),
         nu=1.5,
         prior_bounds=None,
     ):
         self.length_scale = length_scale
-        self.length_scale_bounds = length_scale_bounds
+        self.length_scale_prior = length_scale_prior
         self.nu = nu
         self.prior_bounds = prior_bounds
-        if length_scale_bounds == "dynamic":
+        if isinstance(length_scale_prior, str) and length_scale_prior == "dynamic":
             if prior_bounds is None:
                 raise TypeError(
                     "Prior bounds are required for the Matern kernel "
@@ -366,12 +390,12 @@ class Matern(Kernel, sk_Matern):
             return Hyperparameter(
                 "length_scale",
                 "numeric",
-                self.length_scale_bounds,
+                self.length_scale_prior,
                 self.max_length,
                 len(self.length_scale),
             )
         return Hyperparameter(
-            "length_scale", "numeric", self.length_scale_bounds, self.max_length
+            "length_scale", "numeric", self.length_scale_prior, self.max_length
         )
 
     def gradient_x(self, x, X_train):
@@ -488,16 +512,16 @@ class RationalQuadratic(Kernel, sk_RationalQuadratic):
         self,
         length_scale=1.0,
         alpha=1.0,
-        length_scale_bounds=(1e-5, 1e5),
+        length_scale_prior=(1e-3, 1e1),
         alpha_bounds=(1e-5, 1e5),
         prior_bounds=None,
     ):
         self.length_scale = length_scale
         self.alpha = alpha
-        self.length_scale_bounds = length_scale_bounds
+        self.length_scale_prior = length_scale_prior
         self.alpha_bounds = alpha_bounds
         self.prior_bounds = prior_bounds
-        if length_scale_bounds == "dynamic":
+        if isinstance(length_scale_prior, str) and length_scale_prior == "dynamic":
             if prior_bounds is None:
                 raise TypeError(
                     "Prior bounds are required for the RQ kernel "
@@ -535,12 +559,12 @@ class RationalQuadratic(Kernel, sk_RationalQuadratic):
             return Hyperparameter(
                 "length_scale",
                 "numeric",
-                self.length_scale_bounds,
+                self.length_scale_prior,
                 self.max_length,
                 len(self.length_scale),
             )
         return Hyperparameter(
-            "length_scale", "numeric", self.length_scale_bounds, self.max_length
+            "length_scale", "numeric", self.length_scale_prior, self.max_length
         )
 
     @property
@@ -576,16 +600,16 @@ class ExpSineSquared(Kernel, sk_ExpSineSquared):
         self,
         length_scale=1.0,
         periodicity=1.0,
-        length_scale_bounds=(1e-5, 1e5),
+        length_scale_prior=(1e-3, 1e1),
         periodicity_bounds=(1e-5, 1e5),
         prior_bounds=None,
     ):
         self.length_scale = length_scale
         self.periodicity = periodicity
-        self.length_scale_bounds = length_scale_bounds
+        self.length_scale_prior = length_scale_prior
         self.periodicity_bounds = periodicity_bounds
         self.prior_bounds = prior_bounds
-        if length_scale_bounds == "dynamic":
+        if isinstance(length_scale_prior, str) and length_scale_prior == "dynamic":
             if prior_bounds is None:
                 raise TypeError(
                     "Prior bounds are required for the RQ kernel "
@@ -623,14 +647,14 @@ class ExpSineSquared(Kernel, sk_ExpSineSquared):
             return Hyperparameter(
                 "length_scale",
                 "numeric",
-                self.length_scale_bounds,
+                self.length_scale_prior,
                 len(self.length_scale),
                 max_length=self.max_length,
             )
         return Hyperparameter(
             "length_scale",
             "numeric",
-            self.length_scale_bounds,
+            self.length_scale_prior,
             max_length=self.max_length,
         )
 

--- a/gpry/run.py
+++ b/gpry/run.py
@@ -400,7 +400,7 @@ class Runner:
                 "regressor": {
                     "kernel": "RBF",
                     "output_scale_prior": [1e-2, 1e3],
-                    "length_scale_prior": [1e-3, 1e1],
+                    "length_scale_prior": [1e-3, 1e2],
                     "noise_level": 1e-2,
                     "optimizer": "fmin_l_bfgs_b",
                     "n_restarts_optimizer": 10 + 2 * self.d,

--- a/gpry/surrogate.py
+++ b/gpry/surrogate.py
@@ -202,6 +202,14 @@ class SurrogateModel:
         kwargs_regressor = deepcopy(regressor)
         kwargs_regressor["noise_level"] = self._noise_level_
         kwargs_regressor["random_state"] = random_state
+        # The regressor (and hence its kernel) lives in the transformed space, so the
+        # parameter-space bounds must be transformed too. Only used if a length
+        # correlation kernel is requested with ``length_scale_prior="dynamic"``, but
+        # passed always: it is cheap, and its absence is what silently disabled that
+        # option when the bounds moved out of the GPR.
+        kwargs_regressor["prior_bounds"] = self.preprocessing_X.transform_bounds(
+            self._bounds
+        )
         self.gpr = GaussianProcessRegressor(**kwargs_regressor)
         # Regressor post-processing: clip too high values
         self.clipper = Clipper(clip_factor)


### PR DESCRIPTION
Fixes #3.

## What was wrong

`length_scale_prior` was passed to `length_corr_kernel` under the **`prior_bounds`** keyword instead of `length_scale_bounds`, so the latter silently kept its sklearn default `(1e-5, 1e5)`. Every fit since 39dc81c (2025-07-03, the surrogate/GPR split) optimised the length scales over **10 decades instead of 4**. In the same refactor `self.bounds_` left the GPR, so the real parameter-space bounds stopped reaching the kernel entirely and `"dynamic"` length-scale bounds became unusable.

## What this PR does

Keeps the `length_scale_prior` vocabulary and keeps `"dynamic"` working.

**`10b1381` — the fix**
- `kernels.py`: rename argument/attribute `length_scale_bounds` → `length_scale_prior` in the four length-correlation kernels (RBF, Matern, RationalQuadratic, ExpSineSquared).
- `kernels.py`: guard the four `"dynamic"` comparisons with `isinstance(..., str)`. This was the blocker: `length_scale_prior` is now per-dimension `(d, 2)`, and `array == "dynamic"` raises — which is presumably why the value was moved to `prior_bounds` in the first place.
- `gpr.py`: new optional `prior_bounds` argument (the parameter-space box **in the GPR's own transformed space**), and both quantities passed under their correct names.
- `surrogate.py`: supplies it as `preprocessing_X.transform_bounds(self._bounds)`, restoring the pre-refactor semantics through the new two-layer architecture.
- `kernels.py`: `length_scale_bounds` property alias, and a `__setstate__` migration so surrogates pickled **before** the rename still load (without it, old checkpoints fail inside sklearn's `get_params`).

**`6ddc057` — default raised to `[1e-3, 1e2]`, plus docs**

With the plumbing fixed, the documented `[1e-3, 1e1]` proved too tight — the optimum lies above it. Measured on real surrogates, clamping length scales to 10 costs a lot of log-marginal-likelihood:

| surrogate | fitted ls median | LML(optimum) | LML(ls=10) | loss |
|---|---|---|---|---|
| d16 nuts | 36.5 | 460.2 | −248.4 | 709 nats |
| d16 ultranest | 37.7 | 578.1 | −318.5 | 897 nats |
| d30 nuts | 47.2 | 875.1 | −1643.3 | 2518 nats |
| d30 ultranest | 45.0 | 417.6 | −2053.1 | 2471 nats |

and at d=4 it pegged 3 of 4 length scales at the upper bound. `[1e-3, 1e2]` also coincides with what `"dynamic"` derives for a unit (normalised) box, so the static default now matches the adaptive behaviour in the common case.

Also corrects two docstrings that contradicted the code:
- `Hyperparameter.dynamic` claimed *"two orders of magnitude above and below the current best fit"*; the code uses `[value * 1e-3, value * 100]`, and only when `max_length` is None — otherwise the bounds scale to the prior size. Both branches are now documented.
- `max_length` claimed it restricts the range to *"2x the prior"*; it is 1e-3× to 100×.

## Verification

A/B over 5 seeds (d=4) against a pristine `origin/main` worktree — recovery unchanged within seed noise, clamping gone:

| | ls median | at upper bound | KL median | KL range | sigma error |
|---|---|---|---|---|---|
| `origin/main` (bug) | 13.50 | 0/20 | 0.00655 | [0.0052, 0.0086] | 0.0144 |
| this PR | 13.29 | **0/20** | 0.00823 | [0.0041, 0.0087] | 0.0124 |

Unit checks, all passing: default prior honoured (`[1e-3, 1e2]`, was `[1e-5, 1e5]`); per-dimension priors honoured; output-scale bounds unchanged; `"dynamic"` derives `[width*1e-3, width*100]` per dimension; `"dynamic"` without `prior_bounds` still raises a clear `TypeError`; pre-rename pickles load; alias works.

`pytest tests/` shows the **same 6 failures as `origin/main`** (pre-existing: stale `test_ranked_pool` API, `mc_sample.to_getdist()` vs dict in `test_pipeline`, MC-return arity and a too-small `max_total` in `test_io`, missing cobaya component). No new failures.

## Notes for review

- This changes the outcome of **every** GP fit, so benchmark numbers produced on `main` since 2025-07-03 should be regenerated.
- `prior_bounds` is still only consumed under `"dynamic"`. It is now plumbed through correctly so the option works, rather than removed.
- Naming: the kernel now takes both `length_scale_prior` (prior on the hyperparameter) and `prior_bounds` (the parameter-space box). Both contain "prior" but mean different things, which is plausibly what made the original mix-up easy; renaming `prior_bounds` → `parameter_bounds` would remove the ambiguity, but I left it out to keep this diff focused.
