### PR TITLE
fix(run): assign result of mpi.round_MPI for n_restarts_optimizer

### DIFF
--- a/gpry/run.py
+++ b/gpry/run.py
@@ -425,8 +425,7 @@ class Runner:
                 surrogate["regressor"][nres] = get_Xnumber(
                     surrogate["regressor"][nres], "d", self.d, int, nres
                 )
-                surrogate["regressor"][nres]
-                mpi.round_MPI(
+                surrogate["regressor"][nres] = mpi.round_MPI(
                     surrogate["regressor"][nres],
                     up=False,
                     warn_rounding=True,


### PR DESCRIPTION
## Problem

In `Runner._construct_surrogate` ([gpry/run.py:423-434](https://github.com/jonaselgammal/GPry/blob/main/gpry/run.py#L423-L434)) the code intends to round `n_restarts_optimizer` **down** to a multiple of the MPI size:

```python
surrogate["regressor"][nres]   # <- no-op expression statement
mpi.round_MPI(                 # <- return value discarded
    surrogate["regressor"][nres], up=False, warn_rounding=True, name=nres,
)
```

`mpi.round_MPI` ([gpry/mpi.py:228](https://github.com/jonaselgammal/GPry/blob/main/gpry/mpi.py#L228)) is a pure function — it computes `new_n` and `return`s it, mutating nothing. So the rounding never took effect.

Worse than a silent no-op: the `warn_rounding=True` path still fired, so users were **told** the value had been rounded while the unrounded value was actually used.

## Fix

```python
surrogate["regressor"][nres] = mpi.round_MPI(
    surrogate["regressor"][nres], up=False, warn_rounding=True, name=nres,
)
```

## Verification

Constructed a `Runner` (`d=2`, so the default `n_restarts_optimizer = 10 + 2*d = 14`) with `gpry.mpi.SIZE` patched to 4, since `round_MPI` reads that module global. `mpi4py` is not installed in this environment, so a true multi-process `mpirun` was not exercised.

| | `n_restarts_optimizer` | multiple of `SIZE=4`? | warning emitted |
|---|---|---|---|
| before | 14 | no | "rounded down from 14 to 12" |
| after | 12 | yes | "rounded down from 14 to 12" |

Before the fix the warning and the actual value disagree; after, they match.

With `SIZE = 1` the value stays 14 and no warning is emitted, confirming single-process runs are unaffected.

`flake8 --select=F,B018 gpry/run.py` is clean (it flags the removed no-op statement on `main`).

**Not run:** the `tests/` suite — collection fails on missing `cobaya` in this environment, identically on pristine `main`, so it is pre-existing and unrelated to this change.

## Scope note

While reading `round_MPI` I noticed its `up=True` branch looks separately incorrect — `n // SIZE * (SIZE + (1 if up else 0))` gives `14 // 4 * 5 == 15` rather than 16 for `n=14, SIZE=4`. The `up=False` path used here is correct (`n // SIZE * SIZE`). Left untouched as out of scope for this fix.